### PR TITLE
fix eslint

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tuum-tech/identity-snap.git"
   },
   "source": {
-    "shasum": "Kaj9U7LkQZOE42hETO5+rq1eaO5rlNXOFZs/CTs4g8c=",
+    "shasum": "eL6SDHZZP8BgxIYAutWv9ELPPKwDCND12OX8pL5xNPg=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/snap/tests/rpc/did/resolveDid.spec.ts
+++ b/packages/snap/tests/rpc/did/resolveDid.spec.ts
@@ -3,7 +3,11 @@ import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { IdentitySnapParams, IdentitySnapState } from 'src/interfaces';
 import { resolveDID } from '../../../src/rpc/did/resolveDID';
 import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccount';
-import { exampleDIDPkh, getDefaultSnapState } from '../../testUtils/constants';
+import {
+  exampleDIDPkh,
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('resolveDID', () => {
@@ -17,32 +21,25 @@ describe('resolveDID', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
-  it('should succeed returning current did resolved', async () => {
-    let resolvedDid = await resolveDID(identitySnapParams, exampleDIDPkh);
 
-    console.log('resolved did:' + JSON.stringify(resolvedDid));
-    let id = resolvedDid?.didDocument!['id'];
+  it('should succeed returning current did resolved', async () => {
+    const resolvedDid = await resolveDID(identitySnapParams, exampleDIDPkh);
+    const id = resolvedDid?.didDocument?.id;
 
     expect(id).toEqual(exampleDIDPkh);
 
@@ -50,9 +47,9 @@ describe('resolveDID', () => {
   });
 
   it('should resolve current did when didUrl undefined', async () => {
-    let resolvedDid = await resolveDID(identitySnapParams, undefined);
+    const resolvedDid = await resolveDID(identitySnapParams, undefined);
 
-    let id = resolvedDid?.didDocument!['id'];
+    const id = resolvedDid?.didDocument?.id;
 
     expect(id).toEqual(
       snapState.accountState['0x7d871f006d97498ea338268a956af94ab2e65cdd']

--- a/packages/snap/tests/rpc/gdrive/configureGoogleAccount.spec.ts
+++ b/packages/snap/tests/rpc/gdrive/configureGoogleAccount.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { GoogleToken, IdentitySnapParams } from '../../../src/interfaces';

--- a/packages/snap/tests/rpc/getAvailableMethods.spec.ts
+++ b/packages/snap/tests/rpc/getAvailableMethods.spec.ts
@@ -1,0 +1,19 @@
+import { getAvailableMethods } from '../../src/rpc/did/getAvailableMethods';
+
+describe('GetAvailableMethods', () => {
+  it('should return all available methods', async () => {
+    // get
+    const getAvailableMethodsResult = await getAvailableMethods();
+    expect(getAvailableMethodsResult.length).toBeGreaterThanOrEqual(1);
+
+    expect.assertions(1);
+  });
+
+  it('should contains did:pkh in available methods', async () => {
+    // get
+    const getAvailableMethodsResult = await getAvailableMethods();
+    expect(getAvailableMethodsResult).toContain('did:pkh');
+
+    expect.assertions(1);
+  });
+});

--- a/packages/snap/tests/rpc/hedera/connectHederaAccount.spec.ts
+++ b/packages/snap/tests/rpc/hedera/connectHederaAccount.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { IdentitySnapParams, IdentitySnapState } from '../../../src/interfaces';

--- a/packages/snap/tests/rpc/hedera/getHederaAccountId.spec.ts
+++ b/packages/snap/tests/rpc/hedera/getHederaAccountId.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { GoogleToken, IdentitySnapParams } from '../../../src/interfaces';

--- a/packages/snap/tests/rpc/saveVC.spec.ts
+++ b/packages/snap/tests/rpc/saveVC.spec.ts
@@ -1,0 +1,66 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { SnapsGlobalObject } from '@metamask/snaps-types';
+import { IdentitySnapParams, IdentitySnapState } from '../../src/interfaces';
+import { connectHederaAccount } from '../../src/rpc/hedera/connectHederaAccount';
+import { saveVC } from '../../src/rpc/vc/saveVC';
+import { SaveVCRequestParams } from '../../src/types/params';
+import { getAgent } from '../../src/veramo/setup';
+import { getDefaultSnapState, hederaPrivateKey } from '../testUtils/constants';
+import { getDefaultCredential } from '../testUtils/helper';
+import { createMockSnap, SnapMock } from '../testUtils/snap.mock';
+
+describe('saveVC', () => {
+  let identitySnapParams: IdentitySnapParams;
+  let snapState: IdentitySnapState;
+  let snapMock: SnapsGlobalObject & SnapMock;
+  let metamask: MetaMaskInpageProvider;
+
+  beforeEach(async () => {
+    snapState = getDefaultSnapState();
+    snapMock = createMockSnap();
+    metamask = snapMock as unknown as MetaMaskInpageProvider;
+    identitySnapParams = {
+      metamask,
+      snap: snapMock,
+      state: snapState,
+    };
+
+    (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
+      hederaPrivateKey,
+    );
+
+    (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
+      '0x128',
+    );
+
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
+  });
+
+  it('should succeed saving passing VC', async () => {
+    const agent = await getAgent(snapMock);
+
+    (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
+      true,
+    );
+
+    const identifier = await agent.didManagerCreate({
+      kms: 'snap',
+      provider: 'did:pkh',
+      options: { chainId: '1' },
+    });
+    snapState.accountState[snapState.currentAccount].identifiers[
+      identifier.did
+    ] = identifier;
+
+    const credential = await getDefaultCredential(agent, identifier.did);
+    const params: SaveVCRequestParams = {
+      verifiableCredential: credential,
+      options: {},
+    };
+
+    const result = await saveVC(identitySnapParams, params);
+    expect(result.length).toBe(1);
+
+    expect.assertions(1);
+  });
+});

--- a/packages/snap/tests/rpc/snap/togglePopups.spec.ts
+++ b/packages/snap/tests/rpc/snap/togglePopups.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { IdentitySnapParams, IdentitySnapState } from '../../../src/interfaces';

--- a/packages/snap/tests/rpc/switchMethod.spec.ts
+++ b/packages/snap/tests/rpc/switchMethod.spec.ts
@@ -1,13 +1,10 @@
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
-import { IdentitySnapParams, IdentitySnapState } from 'src/interfaces';
-import { switchMethod } from '../../../src/rpc/did/switchMethods';
-import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccount';
-import {
-  getDefaultSnapState,
-  hederaPrivateKey,
-} from '../../testUtils/constants';
-import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
+import { IdentitySnapParams, IdentitySnapState } from '../../src/interfaces';
+import { switchMethod } from '../../src/rpc/did/switchMethods';
+import { connectHederaAccount } from '../../src/rpc/hedera/connectHederaAccount';
+import { getDefaultSnapState, hederaPrivateKey } from '../testUtils/constants';
+import { createMockSnap, SnapMock } from '../testUtils/snap.mock';
 
 describe('SwitchMethod', () => {
   let identitySnapParams: IdentitySnapParams;

--- a/packages/snap/tests/rpc/vc/createVC.spec.ts
+++ b/packages/snap/tests/rpc/vc/createVC.spec.ts
@@ -3,7 +3,10 @@ import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { IdentitySnapParams, IdentitySnapState } from '../../../src/interfaces';
 import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccount';
 import { createVC } from '../../../src/rpc/vc/createVC';
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('createVC', () => {
@@ -17,30 +20,24 @@ describe('createVC', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
 
   it('should create VC', async () => {
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
     console.log(JSON.stringify(vcCreatedResult));
@@ -54,6 +51,7 @@ describe('createVC', () => {
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
       false,
     );
+
     await expect(
       createVC(identitySnapParams, { vcValue: { prop: 10 } }),
     ).rejects.toThrowError();

--- a/packages/snap/tests/rpc/vc/deleteAllVC.spec.ts
+++ b/packages/snap/tests/rpc/vc/deleteAllVC.spec.ts
@@ -4,7 +4,10 @@ import { IdentitySnapParams, IdentitySnapState } from '../../../src/interfaces';
 import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccount';
 import { createVC } from '../../../src/rpc/vc/createVC';
 import { deleteAllVCs } from '../../../src/rpc/vc/deleteAllVCs';
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('delete all VC', () => {
@@ -18,33 +21,27 @@ describe('delete all VC', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (
       identitySnapParams.snap as SnapMock
-    ).rpcMocks.snap_dialog.mockReturnValueOnce(privateKey);
+    ).rpcMocks.snap_dialog.mockReturnValueOnce(hederaPrivateKey);
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
 
   it('should delete all VC', async () => {
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
       true,
     );
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
     expect(vcCreatedResult.length).toBe(1);
@@ -57,8 +54,6 @@ describe('delete all VC', () => {
   });
 
   it('should throw exception if user refused confirmation', async () => {
-    let snapState: IdentitySnapState = getDefaultSnapState();
-
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
       false,
     );

--- a/packages/snap/tests/rpc/vc/getSupportedProofFormats.spec.ts
+++ b/packages/snap/tests/rpc/vc/getSupportedProofFormats.spec.ts
@@ -3,7 +3,7 @@ import { getSupportedProofFormats } from '../../../src/rpc/vc/getSupportedProofF
 describe('GetSupportedProofFormats', () => {
   it('should return all supported proof formats', async () => {
     // get
-    let getAvailableMethodsResult = await getSupportedProofFormats();
+    const getAvailableMethodsResult = await getSupportedProofFormats();
     expect(getAvailableMethodsResult.length).toBe(3);
     expect(getAvailableMethodsResult).toContain('jwt');
     expect(getAvailableMethodsResult).toContain('lds');

--- a/packages/snap/tests/rpc/vc/getVCs.spec.ts
+++ b/packages/snap/tests/rpc/vc/getVCs.spec.ts
@@ -4,7 +4,10 @@ import { IdentitySnapParams, IdentitySnapState } from 'src/interfaces';
 import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccount';
 import { createVC } from '../../../src/rpc/vc/createVC';
 import { getVCs } from '../../../src/rpc/vc/getVCs';
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('getVCs', () => {
@@ -18,26 +21,20 @@ describe('getVCs', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
 
   it('should succeed returning VCS without filter', async () => {
@@ -47,7 +44,7 @@ describe('getVCs', () => {
 
     await createVC(identitySnapParams, { vcValue: { prop: 10 } });
 
-    let vcsReturned = await getVCs(identitySnapParams, {});
+    const vcsReturned = await getVCs(identitySnapParams, {});
     expect(vcsReturned.length).toEqual(1);
 
     expect.assertions(1);
@@ -57,13 +54,14 @@ describe('getVCs', () => {
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
       true,
     );
+
     await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
       credTypes: ['Login'],
     });
     await createVC(identitySnapParams, { vcValue: { prop: 20 } });
 
-    let vcsReturned = await getVCs(identitySnapParams, {
+    const vcsReturned = await getVCs(identitySnapParams, {
       options: {},
       filter: { type: 'vcType', filter: 'Login' },
     });
@@ -77,10 +75,10 @@ describe('getVCs', () => {
       true,
     );
     await createVC(identitySnapParams, { vcValue: { prop: 10 } });
-    let vcs = await getVCs(identitySnapParams, {});
-    let vcId = vcs[0].metadata.id;
+    const vcs = await getVCs(identitySnapParams, {});
+    const vcId = vcs[0].metadata.id;
 
-    let vcsReturned = await getVCs(identitySnapParams, {
+    const vcsReturned = await getVCs(identitySnapParams, {
       filter: { type: 'id', filter: vcId },
     });
     expect(vcsReturned.length).toEqual(1);

--- a/packages/snap/tests/rpc/vc/removeVC.spec.ts
+++ b/packages/snap/tests/rpc/vc/removeVC.spec.ts
@@ -5,7 +5,10 @@ import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccou
 import { createVC } from '../../../src/rpc/vc/createVC';
 import { getVCs } from '../../../src/rpc/vc/getVCs';
 import { removeVC } from '../../../src/rpc/vc/removeVC';
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('RemoveVC', () => {
@@ -19,26 +22,20 @@ describe('RemoveVC', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
 
   it('should remove VC', async () => {
@@ -54,7 +51,7 @@ describe('RemoveVC', () => {
     expect(getVcsResult.length).toBe(1);
 
     // Remove VC
-    let removeVCResult = await removeVC(identitySnapParams, {
+    const removeVCResult = await removeVC(identitySnapParams, {
       id: getVcsResult[0].metadata.id,
       options: {},
     });
@@ -75,11 +72,11 @@ describe('RemoveVC', () => {
 
     // create VC
     await createVC(identitySnapParams, { vcValue: { prop: 10 } });
-    let getVcsResult = await getVCs(identitySnapParams, {});
+    const getVcsResult = await getVCs(identitySnapParams, {});
 
     expect(getVcsResult.length).toBe(1);
 
-    console.log('res: ' + JSON.stringify(getVcsResult));
+    console.log(`res: ${JSON.stringify(getVcsResult)}`);
 
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
       false,

--- a/packages/snap/tests/rpc/vc/syncGoogleVCs.spec.ts
+++ b/packages/snap/tests/rpc/vc/syncGoogleVCs.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import { IdentitySnapParams, IdentitySnapState } from '../../../src/interfaces';

--- a/packages/snap/tests/rpc/vc/verifyVC.spec.ts
+++ b/packages/snap/tests/rpc/vc/verifyVC.spec.ts
@@ -6,7 +6,10 @@ import { connectHederaAccount } from '../../../src/rpc/hedera/connectHederaAccou
 import { createVC } from '../../../src/rpc/vc/createVC';
 import { getVCs } from '../../../src/rpc/vc/getVCs';
 import { verifyVC } from '../../../src/rpc/vc/verifyVC';
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
 describe('VerifyVC', () => {
@@ -20,27 +23,22 @@ describe('VerifyVC', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
+
   it('should verify VC', async () => {
     // Setup
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
@@ -48,11 +46,11 @@ describe('VerifyVC', () => {
     );
 
     // create VC to verify
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
-    console.log('vcRes' + JSON.stringify(vcCreatedResult));
-    let vc = await getVCs(identitySnapParams, {
+    console.log(`vcRes${JSON.stringify(vcCreatedResult)}`);
+    const vc = await getVCs(identitySnapParams, {
       filter: { type: 'id', filter: vcCreatedResult[0].id },
     });
 
@@ -69,18 +67,18 @@ describe('VerifyVC', () => {
     );
 
     // create VC to verify
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
-    let vc = await getVCs(identitySnapParams, {
+    const vc = await getVCs(identitySnapParams, {
       filter: { type: 'id', filter: vcCreatedResult[0].id },
     });
 
-    let tamperedVc = JSON.parse(JSON.stringify(vc[0].data));
+    const tamperedVc = JSON.parse(JSON.stringify(vc[0].data));
 
-    tamperedVc['issuer']['id'] =
+    tamperedVc.issuer.id =
       'did:pkh:eip155:296:0x7d871f006d97498ea338268a956af94ab2e65cde';
-    console.log('tamp VC ' + JSON.stringify(tamperedVc));
+    console.log(`tamp VC ${JSON.stringify(tamperedVc)}`);
 
     await expect(
       verifyVC(identitySnapParams, tamperedVc as W3CVerifiableCredential),

--- a/packages/snap/tests/rpc/vc/verifyVP.spec.ts
+++ b/packages/snap/tests/rpc/vc/verifyVP.spec.ts
@@ -8,7 +8,10 @@ import { createVP } from '../../../src/rpc/vc/createVP';
 import { verifyVP } from '../../../src/rpc/vc/verifyVP';
 import { createMockSnap, SnapMock } from '../../testUtils/snap.mock';
 
-import { getDefaultSnapState } from '../../testUtils/constants';
+import {
+  getDefaultSnapState,
+  hederaPrivateKey,
+} from '../../testUtils/constants';
 
 describe('VerifyVP', () => {
   let identitySnapParams: IdentitySnapParams;
@@ -21,26 +24,20 @@ describe('VerifyVP', () => {
     snapMock = createMockSnap();
     metamask = snapMock as unknown as MetaMaskInpageProvider;
     identitySnapParams = {
-      metamask: metamask,
+      metamask,
       snap: snapMock,
       state: snapState,
     };
 
-    let privateKey =
-      '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
     (identitySnapParams.snap as SnapMock).rpcMocks.snap_dialog.mockReturnValue(
-      privateKey,
+      hederaPrivateKey,
     );
+
     (identitySnapParams.snap as SnapMock).rpcMocks.eth_chainId.mockReturnValue(
       '0x128',
     );
 
-    let connected = await connectHederaAccount(
-      snapMock,
-      snapState,
-      metamask,
-      '0.0.15215',
-    );
+    await connectHederaAccount(snapMock, snapState, metamask, '0.0.15215');
   });
 
   it('should verify valid VP', async () => {
@@ -50,12 +47,12 @@ describe('VerifyVP', () => {
     );
 
     // create VC
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
 
     // create VP
-    let verifiablePresentation = await createVP(identitySnapParams, {
+    const verifiablePresentation = await createVP(identitySnapParams, {
       vcs: [vcCreatedResult[0].id as string],
     });
 
@@ -75,21 +72,21 @@ describe('VerifyVP', () => {
     );
 
     // create VC
-    let vcCreatedResult = await createVC(identitySnapParams, {
+    const vcCreatedResult = await createVC(identitySnapParams, {
       vcValue: { prop: 10 },
     });
 
     // create VP
-    let verifiablePresentation = await createVP(identitySnapParams, {
+    const verifiablePresentation = await createVP(identitySnapParams, {
       vcs: [vcCreatedResult[0].id as string],
     });
 
-    let adultered = JSON.parse(JSON.stringify(verifiablePresentation));
+    const adultered = JSON.parse(JSON.stringify(verifiablePresentation));
 
-    adultered['proof']['jwt'] =
+    adultered.proof.jwt =
       '1.eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJDdXN0b20iXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlsiZXlKaGJHY2lPaUpGVXpJMU5rc2lMQ0owZVhBaU9pSktWMVFpZlEuZXlKbGVIQWlPakUzTURneU56a3lPRElzSW5aaklqcDdJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk4eU1ERTRMMk55WldSbGJuUnBZV3h6TDNZeElsMHNJblI1Y0dVaU9sc2lWbVZ5YVdacFlXSnNaVU55WldSbGJuUnBZV3dpWFN3aVkzSmxaR1Z1ZEdsaGJGTjFZbXBsWTNRaU9uc2lkbU5FWVhSaElqcDdJbkJ5YjNBaU9qRXdmU3dpYUdWa1pYSmhRV05qYjNWdWRFbGtJam9pTUM0d0xqRTFNakUxSW4xOUxDSnBjM04xWlhJaU9uc2lhR1ZrWlhKaFFXTmpiM1Z1ZEVsa0lqb2lNQzR3TGpFMU1qRTFJbjBzSW5OMVlpSTZJbVJwWkRwd2EyZzZaV2x3TVRVMU9qSTVOam93ZURka09EY3haakF3Tm1RNU56UTVPR1ZoTXpNNE1qWTRZVGsxTm1GbU9UUmhZakpsTmpWalpHUWlMQ0p1WW1ZaU9qRTJOelkzTkRNeU9ESXNJbWx6Y3lJNkltUnBaRHB3YTJnNlpXbHdNVFUxT2pJNU5qb3dlRGRrT0RjeFpqQXdObVE1TnpRNU9HVmhNek00TWpZNFlUazFObUZtT1RSaFlqSmxOalZqWkdRaWZRLmRySGdXTzhSM0lBaHZTbEJZTFNLNnlObnJkTjMwRDkwZFluSmUxN1FtclZ3cS1nU2psQ2REd1dnV1pzRFFxRXZlblRoSHpLeHZIRVVkbmN2Q0xyTkZnIl19LCJuYmYiOjE2NzY3NDMyODIsImlzcyI6ImRpZDpwa2g6ZWlwMTU1OjI5NjoweDdkODcxZjAwNmQ5NzQ5OGVhMzM4MjY4YTk1NmFmOTRhYjJlNjVjZGQifQ.3rRRKLtrTcsiAzXHgmQVjZOG2YZKBxomIwbZC6nFPaUNyaBTLOLEw8ZAmVpdWRXA-K7OjlPtcyaz4IMn-iaUlg';
 
-    //console.log("adultered Presentation " + JSON.stringify(adultered));
+    // console.log("adultered Presentation " + JSON.stringify(adultered));
 
     await expect(
       verifyVP(identitySnapParams, adultered as VerifiablePresentation),

--- a/packages/snap/tests/testUtils/constants.ts
+++ b/packages/snap/tests/testUtils/constants.ts
@@ -7,6 +7,7 @@ export const privateKey =
 
 export const hederaPrivateKey =
   '2386d1d21644dc65d4e4b9e2242c5f155cab174916cbc46ad85622cdaeac835c';
+
 export const hederaAccountId = '0.0.15215';
 export const hederaAddress = '0x7d871f006d97498ea338268a956af94ab2e65cdd';
 
@@ -37,11 +38,11 @@ const defaultSnapState: IdentitySnapState = {
 };
 
 export const getDefaultSnapState = (): IdentitySnapState => {
-  //defaultSnapState.accountState[address].publicKey = publicKey;
+  // defaultSnapState.accountState[address].publicKey = publicKey;
   return cloneDeep(defaultSnapState);
 };
 
 export const getSnapStateWithIdentifiers = (): IdentitySnapState => {
-  let snapStateWithIdentifiers = getDefaultSnapState();
+  const snapStateWithIdentifiers = getDefaultSnapState();
   return snapStateWithIdentifiers;
 };

--- a/packages/snap/tests/testUtils/helper.ts
+++ b/packages/snap/tests/testUtils/helper.ts
@@ -3,9 +3,9 @@ import { VerifiableCredential } from 'did-jwt-vc';
 export const getDefaultCredential = async (
   agent: any,
   did: string,
-  type: string = 'Default',
+  type = 'Default',
 ): Promise<VerifiableCredential> => {
-  let vc = await agent.createVerifiableCredential({
+  const vc = await agent.createVerifiableCredential({
     credential: {
       issuer: { id: did },
       '@context': [

--- a/packages/snap/tests/testUtils/snap.mock.ts
+++ b/packages/snap/tests/testUtils/snap.mock.ts
@@ -1,20 +1,21 @@
+/* eslint-disable */
+
 import { RequestArguments } from '@metamask/providers/dist/BaseProvider';
 import { Maybe } from '@metamask/providers/dist/utils';
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 
 import { providers, Wallet } from 'ethers';
-//import { BIP44CoinTypeNode } from '@metamask/key-tree';
 import { IdentitySnapState } from '../../src/interfaces';
 import { address, privateKey } from './constants';
 
-interface ISnapMock {
+type ISnapMock = {
   request<T>(args: RequestArguments): Promise<Maybe<T>>;
   resetHistory(): void;
-}
-interface SnapManageState {
+};
+type SnapManageState = {
   operation: 'get' | 'update' | 'clear';
   newState: unknown;
-}
+};
 
 export class SnapMock implements ISnapMock {
   private snapState: IdentitySnapState | null = null;
@@ -25,9 +26,11 @@ export class SnapMock implements ISnapMock {
     if (!params) {
       return null;
     }
+
     if (params.operation === 'get') {
       return this.snapState;
     }
+
     if (params.operation === 'update') {
       this.snapState = params.newState as IdentitySnapState;
     } else if (params.operation === 'clear') {
@@ -114,6 +117,11 @@ export class SnapMock implements ISnapMock {
   }
 }
 
+/**
+ * Creates and returns a Mock Snap
+ *
+ * @returns {SnapsGlobalObject & SnapMock} SnapMock
+ */
 export function createMockSnap(): SnapsGlobalObject & SnapMock {
   return new SnapMock() as SnapsGlobalObject & SnapMock;
 }

--- a/packages/snap/tests/utils/snapUtils.spec.disabled.ts
+++ b/packages/snap/tests/utils/snapUtils.spec.disabled.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 // import { SnapProvider } from '@metamask/snap-types';
 // import {
 //   addFriendlyDapp, getCurrentNetwork,


### PR DESCRIPTION
Fix eslint errors.

I disabled eslint in some files created because the tests are not yet implemented:
- configureGoogleAccount.spec.ts
- connectHederaAccount.spec.ts
- getHederaAccountId.spec.ts
- togglePopups.spec.ts

 