### PR TITLE
fix warnings

### DIFF
--- a/packages/snap/tests/rpc/vc/verifyVC.spec.ts
+++ b/packages/snap/tests/rpc/vc/verifyVC.spec.ts
@@ -85,18 +85,4 @@ describe('VerifyVC', () => {
     ).resolves.toBe(false);
     expect.assertions(1);
   });
-
-  // it.skip('should throw exception if user refused confirmation', async () => {
-
-  //     // Setup
-  //   walletMock.rpcMocks.snap_confirm.mockReturnValue(true);
-
-  //   // create VC to verify
-  //   let vcCreatedResult = await createVC(walletMock, snapState, { vcValue: {'prop':12} });
-  //   let vc = await getVCs(walletMock, snapState, {filter: {type: 'id', filter: vcCreatedResult[0].id}})
-
-  //   walletMock.rpcMocks.snap_confirm.mockReturnValue(false);
-  //   await expect(verifyVC(walletMock, snapState, vc[0].data as W3CVerifiableCredential)).rejects.toThrowError();
-  //   expect.assertions(1);
-  // });
 });

--- a/packages/snap/tests/utils/init.spec.disabled.ts
+++ b/packages/snap/tests/utils/init.spec.disabled.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import { SnapProvider } from '@metamask/snap-types';
 import { getInitialSnapState } from '../../src/utils/config';
 import { init } from '../../src/utils/init';

--- a/packages/snap/tests/utils/stateUtils.spec.disabled.ts
+++ b/packages/snap/tests/utils/stateUtils.spec.disabled.ts
@@ -1,9 +1,11 @@
+/* eslint-disable */
+
 import { SnapsGlobalObject } from '@metamask/snaps-types';
 import {
   getSnapStateUnchecked,
   initAccountState,
   initSnapState,
-  updateSnapState,
+  updateSnapState
 } from '../../src/snap/state';
 import { getInitialSnapState } from '../../src/utils/config';
 import { address, getDefaultSnapState } from '../testUtils/constants';


### PR DESCRIPTION
- Followed suggestions to fix warnings
- disable eslint for outdated skipped test files that should be refactored and are still there for reference 